### PR TITLE
Remove dependency on `Tilt.mappings` method

### DIFF
--- a/lib/sinatra/assetpack.rb
+++ b/lib/sinatra/assetpack.rb
@@ -15,6 +15,8 @@ module Sinatra
 
     # Returns a map of what MIME format each Tilt type returns.
     def self.tilt_formats
+      # Early return to prevent this method from causing errors on Sinatra > 1.4.0
+      return {} unless Tilt.respond_to?(:mappings)
       @formats ||= begin
         hash = Hash.new
         Tilt.mappings.each do |format, (engine, _)|


### PR DESCRIPTION
With Sinatra versions newer than 1.4.0, `Tilt.mappings` does not exist.

Not sure what effect this method had in the first place, but making it return early if `Tilt.mappings` is not defined does not seem to break
anything for me.